### PR TITLE
Add IN_PROGRESS to imageScanStatus

### DIFF
--- a/src/ecr.ts
+++ b/src/ecr.ts
@@ -109,6 +109,8 @@ async function pollForScanCompletion(
         return;
       } else if (resp.imageScanStatus?.status === 'PENDING') {
         core.info(`Scan status is "Pending"`);
+      } else if (resp.imageScanStatus?.status === 'IN_PROGRESS') {
+        core.info(`Scan status is "In Progress"`);
       } else {
         throw new Error(`Unknown status: ${resp.imageScanStatus!.status}`);
       }


### PR DESCRIPTION
# Description of the issue
- It fails to run with the error below.
<img width="497" alt="image" src="https://github.com/user-attachments/assets/6f0fd5e4-556b-4334-86aa-5c29d662b9df">

```bash
Error: Unknown status: IN_PROGRESS
```

- We should only add statuses that we expect the scan to perform normally.
- Since the `IN_PROGRESS` status is also expected to complete the scan normally, it seems that it should be exceptioned the same as PENDING in pollForScanCompletion function.

# Description of changes
- Added an additional check for the IN_PROGRESS scan status in the pollForScanCompletion function.